### PR TITLE
Fix catch polymophic type by value warning

### DIFF
--- a/computerVision/brick/computerVision/keypointSelectorBullseye_impl.hh
+++ b/computerVision/brick/computerVision/keypointSelectorBullseye_impl.hh
@@ -763,7 +763,7 @@ namespace brick {
           m_bullseyePoints.begin(), m_bullseyePoints.end(),
           m_bullseyeEdgeCounts.begin(), m_bullseyeEdgeCounts.end(),
           residuals.begin());
-      } catch(brick::common::ValueException) {
+      } catch(brick::common::ValueException &) {
         // Input points weren't good enough to define a bullseye.
         return false;
       }
@@ -860,7 +860,7 @@ namespace brick {
         bullseye.estimate(
           inliers.begin(), inliers.end(),
           m_bullseyeEdgeCounts.begin(), m_bullseyeEdgeCounts.end(), false);
-      } catch(brick::common::ValueException) {
+      } catch(brick::common::ValueException &) {
         // If this call throws, we'll just return the un-updated
         // bullseye.
       }

--- a/geometry/brick/geometry/bullseye2D_impl.hh
+++ b/geometry/brick/geometry/bullseye2D_impl.hh
@@ -289,7 +289,7 @@ namespace brick {
         TT = (Type(-1)
               * brick::numeric::matrixMultiply<Type>(
                 brick::linearAlgebra::inverse(S3), S2.transpose()));
-      } catch(brick::common::ValueException) {
+      } catch(brick::common::ValueException &) {
         BRICK_THROW(brick::common::ValueException,
                     "Bullseye2D::estimate()",
                     "Input points are not sufficient to estimate bullseye.");

--- a/geometry/brick/geometry/ellipse2D_impl.hh
+++ b/geometry/brick/geometry/ellipse2D_impl.hh
@@ -194,7 +194,7 @@ namespace brick {
         TT = (Type(-1)
               * brick::numeric::matrixMultiply<Type>(
                 brick::linearAlgebra::inverse(S3), S2.transpose()));
-      } catch(brick::common::ValueException) {
+      } catch(brick::common::ValueException &) {
         BRICK_THROW(brick::common::ValueException,
                     "Ellipse2D::estimate()",
                     "Input points are not sufficient to estimate ellipse.");

--- a/geometry/brick/geometry/triangle2D_impl.hh
+++ b/geometry/brick/geometry/triangle2D_impl.hh
@@ -201,7 +201,7 @@ namespace brick {
 
         triangle.setValue(vertex0, vertex1, vertex2);
 
-      } catch(std::ios_base::failure) {
+      } catch(std::ios_base::failure &) {
         // Empty
       }
       stream.exceptions(oldExceptionState);

--- a/geometry/brick/geometry/triangle3D_impl.hh
+++ b/geometry/brick/geometry/triangle3D_impl.hh
@@ -170,7 +170,7 @@ namespace brick {
 
         triangle.setValue(vertex0, vertex1, vertex2);
 
-      } catch(std::ios_base::failure) {
+      } catch(std::ios_base::failure &) {
         // Empty
       }
       stream.exceptions(oldExceptionState);

--- a/geometry/brick/geometry/utilities3D_impl.hh
+++ b/geometry/brick/geometry/utilities3D_impl.hh
@@ -282,7 +282,7 @@ namespace brick {
       brick::numeric::Array2D<Type> APinv;
       try {
         APinv = privateCode::pseudoinverse(AMatrix);
-      } catch(brick::common::ValueException ) {
+      } catch(brick::common::ValueException &) {
         BRICK_THROW(brick::common::ValueException, "findIntersect()",
                   "Trouble inverting matrix.  "
                   "Perhaps input rays are parallel.");

--- a/numeric/brick/numeric/CMakeLists.txt
+++ b/numeric/brick/numeric/CMakeLists.txt
@@ -70,7 +70,7 @@ install (FILES
   vector2D.hh vector2D_impl.hh
   vector3D.hh vector3D_impl.hh
   utilities.hh utilities_impl.hh
-  
+
   DESTINATION include/brick/numeric)
 
 

--- a/numeric/brick/numeric/array1D_impl.hh
+++ b/numeric/brick/numeric/array1D_impl.hh
@@ -340,7 +340,7 @@ namespace brick {
         this->reinit(inputBuffer.size());
         std::copy(inputBuffer.begin(), inputBuffer.end(), this->begin());
 
-      } catch(std::ios_base::failure) {
+      } catch(std::ios_base::failure &) {
         // Empty
       }
       inputStream.exceptions(oldExceptionState);

--- a/numeric/brick/numeric/array2D_impl.hh
+++ b/numeric/brick/numeric/array2D_impl.hh
@@ -534,7 +534,7 @@ namespace brick {
           std::copy(inputBuffer[index].begin(), inputBuffer[index].end(),
                     this->begin() + (index * arrayColumns));
         }
-      } catch(std::ios_base::failure) {
+      } catch(std::ios_base::failure &) {
         // Empty
       }
       inputStream.exceptions(oldExceptionState);

--- a/numeric/brick/numeric/array3D_impl.hh
+++ b/numeric/brick/numeric/array3D_impl.hh
@@ -356,7 +356,7 @@ namespace brick {
           std::copy(inputBuffer[index].begin(), inputBuffer[index].end(),
                     this->begin() + (index * sliceSize));
         }
-      } catch(std::ios_base::failure) {
+      } catch(std::ios_base::failure &) {
         // Empty
       }
       inputStream.exceptions(oldExceptionState);

--- a/numeric/brick/numeric/staticArray1D_impl.hh
+++ b/numeric/brick/numeric/staticArray1D_impl.hh
@@ -521,7 +521,7 @@ namespace brick {
         // Now we're done with all of the parsing.  Copy the data to *this.
         std::copy(inputBuffer.begin(), inputBuffer.end(), this->begin());
 
-      } catch(std::ios_base::failure) {
+      } catch(std::ios_base::failure &) {
         // Empty
       }
       inputStream.exceptions(oldExceptionState);

--- a/numeric/brick/numeric/transform2D_impl.hh
+++ b/numeric/brick/numeric/transform2D_impl.hh
@@ -578,7 +578,7 @@ namespace brick {
           inputValues[3], inputValues[4], inputValues[5],
           inputValues[6], inputValues[7], inputValues[8]);
 
-      } catch(std::ios_base::failure) {
+      } catch(std::ios_base::failure &) {
         // Empty
       }
       stream.exceptions(oldExceptionState);

--- a/numeric/brick/numeric/transform3DTo2D_impl.hh
+++ b/numeric/brick/numeric/transform3DTo2D_impl.hh
@@ -488,7 +488,7 @@ namespace brick {
                                 inputValues[6], inputValues[7],
                                 inputValues[8], inputValues[9],
                                 inputValues[10], inputValues[11]);
-      } catch(std::ios_base::failure) {
+      } catch(std::ios_base::failure &) {
         // Empty
       }
       stream.exceptions(oldExceptionState);

--- a/numeric/brick/numeric/transform3D_impl.hh
+++ b/numeric/brick/numeric/transform3D_impl.hh
@@ -844,7 +844,7 @@ namespace brick {
                                 inputValues[10], inputValues[11],
                                 inputValues[12], inputValues[13],
                                 inputValues[14], inputValues[15]);
-      } catch(std::ios_base::failure) {
+      } catch(std::ios_base::failure &) {
         // Empty
       }
       stream.exceptions(oldExceptionState);


### PR DESCRIPTION
Add fix for catch value warning which produces the following error (`std::ios_base::failure` in this example) with g++-8.4.0 (Note this fix is also compatible with g++-7).

```
error: catching polymorphic type ‘class std::ios_base::failure’ by value [-Werror=catch-value=]
       } catch(std::ios_base::failure) {
         ^~~~~
``` 